### PR TITLE
updated link to elm-lang/html on website

### DIFF
--- a/elm-src/HtmlToElmWebsite/Main.elm
+++ b/elm-src/HtmlToElmWebsite/Main.elm
@@ -132,7 +132,7 @@ rightPanel model =
                 , class "right-panel-heading"
                 ]
                 [ text "Elm code appears here (see "
-                , a [href "https://github.com/evancz/elm-html", target "_blank"] [ text "elm-html"]
+                , a [href "https://github.com/elm-lang/html", target "_blank"] [ text "elm-lang/html"]
                 , text ")"
                 ]
             , div


### PR DESCRIPTION
The link was still pointing to the deprecated repository of Evan over at https://github.com/evancz/elm-html. I quickly updated the view to point to the new official repo.